### PR TITLE
minor typo in SAB

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,8 +6,8 @@ Authors@R:
     person(given = "Philip", family = "Boonstra", role = c("aut"), email = "philb@umich.edu"),
     person(given = "Michael", family = "Kleinsasser", role = c("cre"), email = "mkleinsa@umich.edu"))
 Description: R package for Boonstra, Philip S. and Barbaro, Ryan P., “Incorporating 
-    Historical Models with Adaptive Bayesian Updates” (2018) In Press at Biostatistics.
-    <doi:10.5281/zenodo.1404430>
+    Historical Models with Adaptive Bayesian Updates” (2020) *Biostatistics* 21, e47--e64.
+    <doi:10.1093/biostatistics/kxy053>
 License: MIT
 Encoding: UTF-8
 LazyData: true

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A companion repository for this package exists at
 https://www.github.com/psboonstra/AdaptiveBayesianUpdates, 
 which contains a vignette (`vignette.pdf`) on using the adaptive priors in this 
 package as well as code for running the simulation studies in Boonstra and 
-Barbaro (2018). 
+Barbaro (2020). 
 
 ### Compilation warning
 
@@ -56,7 +56,7 @@ http://discourse.mc-stan.org/t/very-mysterious-debug-error-when-running-rstanarm
 ### Current Suggested Citation
 
 Boonstra, Philip S. and Barbaro, Ryan P., "Incorporating Historical Models
-with Adaptive Bayesian Updates" (2018) *Biostatistics* 
+with Adaptive Bayesian Updates" (2020) *Biostatistics* 21, e47--e64
 https://doi.org/10.1093/biostatistics/kxy053
 
 <a href="https://biostats.bepress.com/umichbiostat/paper124">Authors' Copy </a>

--- a/inst/stan/SAB_Stable.stan
+++ b/inst/stan/SAB_Stable.stan
@@ -13,10 +13,10 @@ data {
   real<lower = 0> local_dof_stan; // dof of pi(lambda), = 1
   real<lower = 0> global_dof_stan; // dof of pi(tau), = 1
   real<lower = 0> beta_orig_scale_stan; // c, Section 2
-  real<lower = 0> beta_aug_scale_stan; // c, Section 2 
+  real<lower = 0> beta_aug_scale_stan; // c, Section 2
   real<lower = 0> slab_precision_stan; // 1/d^2, Section 2
-  vector<lower = 0>[p_stan] scale_to_variance225; //Equation (S6); equal to diag(S_alpha) / 225; 
-  real<lower = 0, upper = 1> phi_mean_stan; // mean of phi in (0,1) using normal distribution truncated to [0,1]. 
+  vector<lower = 0>[p_stan] scale_to_variance225; //Equation (S6); equal to diag(S_alpha) / 225;
+  real<lower = 0, upper = 1> phi_mean_stan; // mean of phi in (0,1) using normal distribution truncated to [0,1].
   real<lower = 0> phi_sd_stan; // sd of phi using normal distribution truncated to [0,1]
   int<lower = 0,upper = 1> only_prior;//if 1, ignore the model and data and generate from the prior only
 }
@@ -26,8 +26,8 @@ transformed data {
 }
 parameters {
   real mu;
-  vector[p_stan] beta_raw_orig; // unscaled 
-  vector[q_stan] beta_raw_aug; // unscaled 
+  vector[p_stan] beta_raw_orig; // unscaled
+  vector[q_stan] beta_raw_aug; // unscaled
   real<lower = 0> eta;
   real<lower = 0> tau_glob; // tau
   vector<lower = 0>[p_stan] lambda_orig;// lambda^o
@@ -41,14 +41,14 @@ transformed parameters {
   vector[p_stan + q_stan] beta;
   vector<lower = 0,upper = sqrt(1/slab_precision_stan)>[p_stan] theta_orig;// theta
   vector<lower = 0,upper = sqrt(1/slab_precision_stan)>[q_stan] theta_aug;// theta
-  vector<lower = 0,upper = sqrt(1/min(scale_to_variance225))>[p_stan] hist_orig_scale;//Gamma in LHS of Eqn (S6)
+  vector<lower = 0>[p_stan] hist_orig_scale;//Diagonal of Gamma^{-1} in LHS of Eqn (S6)
   matrix[p_stan,p_stan] normalizing_cov;// S_alpha * hist_orig_scale  + Theta^o
   real<lower = 0, upper = 1> phi_copy;// copy of phi
   if(phi_sd_stan > 0) {
     phi_copy = phi;
   } else {
-    phi_copy = phi_mean_stan;  
-  } 
+    phi_copy = phi_mean_stan;
+  }
   theta_orig = 1 ./ sqrt(slab_precision_stan + ((1 - phi_copy) ./ (tau_glob^2 * square(lambda_orig))));
   theta_aug = 1 ./ sqrt(slab_precision_stan + (1 ./ (tau_glob^2 * square(lambda_aug))));
   beta_orig = theta_orig .* beta_raw_orig;


### PR DESCRIPTION
I deleted the upper bound for a transformed parameter (hist_orig_scale) in SAB. 
I also updated the citation.  